### PR TITLE
Automate version code generation as part of the release pipeline/script

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+// versionCode is injected by the release script as -Pversion.code=N
+// (MAJOR*10000 + MINOR*100 + PATCH, e.g. 0.1.0 → 100, 1.2.3 → 10203)
+// Falls back to 1 for local development builds.
+val versionCodeProp = (project.findProperty("version.code") as String?)?.toInt() ?: 1
+
 android {
     namespace = "org.merlos.openme"
     compileSdk = 35
@@ -13,7 +18,7 @@ android {
         applicationId = "org.merlos.openme"
         minSdk = 29
         targetSdk = 35
-        versionCode = 1
+        versionCode = versionCodeProp
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/scripts/release-android.sh
+++ b/android/scripts/release-android.sh
@@ -147,12 +147,18 @@ else
     fi
 fi
 
+# ── Compute versionCode from semver (MAJOR*10000 + MINOR*100 + PATCH) ───────
+# e.g. 0.1.0 → 100 · 0.2.0 → 200 · 1.0.0 → 10000 · 1.2.3 → 10203
+IFS='.' read -r VER_MAJOR VER_MINOR VER_PATCH <<< "$VERSION"
+VERSION_CODE=$(( ${VER_MAJOR:-0} * 10000 + ${VER_MINOR:-0} * 100 + ${VER_PATCH:-0} ))
+
 # ── Setup output dir ──────────────────────────────────────────────────────────
 mkdir -p "$OUTPUT_DIR"
 
 echo "══════════════════════════════════════════════════"
 echo "  openme-android local release"
 echo "  version   : $VERSION"
+echo "  versionCode: $VERSION_CODE"
 echo "  output    : $OUTPUT_DIR"
 echo "  sign APK  : $DO_SIGN"
 echo "══════════════════════════════════════════════════"
@@ -172,7 +178,7 @@ fi
 # ── Step 2: Debug APK ─────────────────────────────────────────────────────────
 echo ""
 echo "── Building debug APK ──"
-./gradlew :app:assembleDebug
+./gradlew :app:assembleDebug "-Pversion.code=$VERSION_CODE"
 
 DEBUG_SRC="$ANDROID_DIR/app/build/outputs/apk/debug/app-debug.apk"
 DEBUG_OUT="$OUTPUT_DIR/openme-${VERSION}-debug.apk"
@@ -184,6 +190,7 @@ if [[ "$DO_SIGN" == true ]]; then
     echo ""
     echo "── Building signed release APK ──"
     ./gradlew :app:assembleRelease \
+        "-Pversion.code=$VERSION_CODE" \
         "-Pandroid.injected.signing.store.file=$KEYSTORE_FILE" \
         "-Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD" \
         "-Pandroid.injected.signing.key.alias=$KEY_ALIAS" \
@@ -206,6 +213,7 @@ elif [[ "$DO_SIGN" == true ]]; then
     echo ""
     echo "── Building signed release AAB (Google Play) ──"
     ./gradlew :app:bundleRelease \
+        "-Pversion.code=$VERSION_CODE" \
         "-Pandroid.injected.signing.store.file=$KEYSTORE_FILE" \
         "-Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD" \
         "-Pandroid.injected.signing.key.alias=$KEY_ALIAS" \


### PR DESCRIPTION
This pull request updates the way the Android app's `versionCode` is managed, ensuring it is automatically computed from the semantic version and consistently injected into builds, both for local development and release automation. This streamlines the release process and reduces manual errors.

**Automated versionCode management:**

* The `versionCode` is now computed from the semantic version (MAJOR*10000 + MINOR*100 + PATCH) in the release script, ensuring unique and incrementing codes for each release.
* The computed `versionCode` is injected into Gradle builds via the `-Pversion.code` property for both debug and release APK/AAB builds in the release script. [[1]](diffhunk://#diff-690b5575283d13f410a10259e846a31117087202b008d311a2659bf129b6585cL175-R181) [[2]](diffhunk://#diff-690b5575283d13f410a10259e846a31117087202b008d311a2659bf129b6585cR193) [[3]](diffhunk://#diff-690b5575283d13f410a10259e846a31117087202b008d311a2659bf129b6585cR216)
* The Gradle build script (`android/app/build.gradle.kts`) now reads `versionCode` from the injected property, defaulting to 1 for local development builds. [[1]](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbR8-R12) [[2]](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbL16-R21)