### PR TITLE
Fix #41 docs on release

### DIFF
--- a/.github/workflows/docs-on-release.yml
+++ b/.github/workflows/docs-on-release.yml
@@ -1,0 +1,31 @@
+# =============================================================================
+# docs-on-release.yml
+#
+# Triggers the Docs workflow on main whenever any release is published.
+# The Docs workflow deploys to GitHub Pages, which only allows deployments
+# from protected refs (main).  This workflow runs under the tag ref but only
+# dispatches docs.yml on main — it never deploys anything itself.
+# gen-variables.sh inside the docs build fetches the latest release versions
+# via the GitHub API, so the new version is picked up automatically.
+# =============================================================================
+name: Trigger docs rebuild on release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  actions: write
+
+jobs:
+  trigger:
+    name: Re-trigger Docs workflow on main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch docs.yml on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run docs.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,22 +1,20 @@
 name: Docs
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'website/**'
-      - 'apple/OpenMeKit/**'
-      - 'android/openmekit/**'
-      - 'c/openmelib/include/**'
-      - 'c/openmelib/src/**'
-      - 'c/openmelib/Doxyfile'
-      - 'windows/OpenMeKit/**'
-      - '.github/workflows/docs.yml'
+  #push:
+  #  branches:
+  #    - main
+  #  paths:
+  #    - 'docs/**'
+  #    - 'website/**'
+  #    - 'apple/OpenMeKit/**'
+  #    - 'android/openmekit/**'
+  #    - 'c/openmelib/include/**'
+  #    - 'c/openmelib/src/**'
+  #    - 'c/openmelib/Doxyfile'
+  #    - 'windows/OpenMeKit/**'
+  #    - '.github/workflows/docs.yml'
   workflow_dispatch:
-  release:
-    types: [published]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
* Whenever there is a release, docs are run from main 
* Now, docs are not generated on each commit to main. Needs to be done manually or through a release

Aims to closes#41 (cannot be tested locally...)