### PR TITLE
server: validate port group existence in 'add'. Skip non existing port goups in 'serve'

### DIFF
--- a/cli/cmd/openme/main.go
+++ b/cli/cmd/openme/main.go
@@ -632,7 +632,9 @@ func buildClientRecords(cfg *config.ServerConfig) ([]*server.ClientRecord, error
 		}
 		ports, err := config.EffectivePorts(cfg.Ports, entry)
 		if err != nil {
-			return nil, fmt.Errorf("client %q: resolving ports: %w", name, err)
+			// Unknown port group — warn and skip this client so the server still starts.
+			fmt.Fprintf(os.Stderr, "warning: client %q skipped: %v\n", name, err)
+			continue
 		}
 		srvPorts := make([]server.PortRule, 0, len(ports)+1)
 
@@ -1023,6 +1025,13 @@ func runAdd(name string, showQR bool, qrOut string, omitPriv bool, expires, port
 			if part != "" {
 				portSpecs = append(portSpecs, config.PortSpec(part))
 			}
+		}
+	}
+
+	// Validate: named groups must exist in cfg.Ports; inline specs must parse.
+	for _, spec := range portSpecs {
+		if _, err := config.ValidatePortSpec(spec, cfg.Ports); err != nil {
+			return fmt.Errorf("invalid port spec %q: %w", spec, err)
 		}
 	}
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -383,6 +383,40 @@ func EffectivePorts(groups map[string][]PortSpec, client *ClientEntry) ([]PortRu
 	return rules, nil
 }
 
+// ValidatePortSpec checks that a single PortSpec is either a valid inline port
+// spec (parseable by ExpandPortSpec) or a named group that exists in groups.
+// It returns nil on success, or a descriptive error on failure.
+//
+// Use this during client registration (openme add) to catch typos early.
+func ValidatePortSpec(spec PortSpec, groups map[string][]PortSpec) ([]PortRule, error) {
+	s := strings.TrimSpace(string(spec))
+	looksLikeGroup := !strings.Contains(s, "/") && !strings.Contains(s, "-") && !isAllDigits(s)
+	if looksLikeGroup {
+		if _, ok := groups[s]; !ok {
+			return nil, fmt.Errorf("unknown port group %q (defined groups: %s)",
+				s, joinGroupNames(groups))
+		}
+		return nil, nil // group exists; full expansion not needed here
+	}
+	return ExpandPortSpec(spec)
+}
+
+// joinGroupNames returns a comma-separated sorted list of group names for
+// inclusion in error messages.
+func joinGroupNames(groups map[string][]PortSpec) string {
+	names := make([]string, 0, len(groups))
+	for k := range groups {
+		names = append(names, k)
+	}
+	// Sort for deterministic output.
+	for i := 1; i < len(names); i++ {
+		for j := i; j > 0 && names[j] < names[j-1]; j-- {
+			names[j], names[j-1] = names[j-1], names[j]
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
 // Duration is a wrapper around time.Duration that supports YAML marshalling
 // in human-readable form (e.g. "30s", "1m").
 type Duration struct {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -300,6 +301,67 @@ func TestEffectivePorts_NoProtoSpec(t *testing.T) {
 	}
 	if len(rules) != 2 {
 		t.Fatalf("got %d rules, want 2", len(rules))
+	}
+}
+
+// ─── ValidatePortSpec tests ───────────────────────────────────────────────────
+
+func TestValidatePortSpec_KnownGroup(t *testing.T) {
+	groups := map[string][]config.PortSpec{"default": {"22/tcp"}, "admin": {"443/tcp"}}
+
+	if _, err := config.ValidatePortSpec("default", groups); err != nil {
+		t.Errorf("expected no error for known group, got %v", err)
+	}
+	if _, err := config.ValidatePortSpec("admin", groups); err != nil {
+		t.Errorf("expected no error for known group, got %v", err)
+	}
+}
+
+func TestValidatePortSpec_UnknownGroup(t *testing.T) {
+	groups := map[string][]config.PortSpec{"default": {"22/tcp"}}
+
+	_, err := config.ValidatePortSpec("doesnotexist", groups)
+	if err == nil {
+		t.Fatal("expected error for unknown group, got nil")
+	}
+	// Error message should include the bad name and the list of valid groups.
+	if !strings.Contains(err.Error(), "doesnotexist") {
+		t.Errorf("error %q should mention the bad group name", err)
+	}
+	if !strings.Contains(err.Error(), "default") {
+		t.Errorf("error %q should list defined groups", err)
+	}
+}
+
+func TestValidatePortSpec_ValidInlineSpec(t *testing.T) {
+	groups := map[string][]config.PortSpec{}
+
+	cases := []config.PortSpec{"22/tcp", "53/udp", "8080", "80-82/tcp", "2000-2010"}
+	for _, spec := range cases {
+		if _, err := config.ValidatePortSpec(spec, groups); err != nil {
+			t.Errorf("spec %q: unexpected error: %v", spec, err)
+		}
+	}
+}
+
+func TestValidatePortSpec_InvalidInlineSpec(t *testing.T) {
+	groups := map[string][]config.PortSpec{}
+
+	cases := []config.PortSpec{"99999/tcp", "abc/tcp", "22/icmp", ""}
+	for _, spec := range cases {
+		if _, err := config.ValidatePortSpec(spec, groups); err == nil {
+			t.Errorf("spec %q: expected error, got nil", spec)
+		}
+	}
+}
+
+func TestValidatePortSpec_EmptyGroups(t *testing.T) {
+	// A named group reference against an empty groups map should fail.
+	groups := map[string][]config.PortSpec{}
+
+	_, err := config.ValidatePortSpec("default", groups)
+	if err == nil {
+		t.Fatal("expected error when no groups are defined, got nil")
 	}
 }
 


### PR DESCRIPTION
closes #49 