### PR TITLE
macOS: Fix post knock not working

### DIFF
--- a/apple/openme-macos/openme-macos/Views/MenuBarMenuView.swift
+++ b/apple/openme-macos/openme-macos/Views/MenuBarMenuView.swift
@@ -12,6 +12,10 @@ struct MenuBarMenuView: View {
     @State private var feedbackMessage: String? = nil
     @State private var feedbackTimer: Timer? = nil
 
+    // Tracks which profiles have already had their post-knock action run during
+    // the current continuous knock session. Cleared when continuous knock stops.
+    @State private var continuousPostKnockFired: Set<String> = []
+
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.1-dev"
     }
@@ -94,19 +98,21 @@ struct MenuBarMenuView: View {
         Menu(entry.name) {
             Button("Knock") {
                 knockManager.knock(profile: entry.id) { result in
-                    showFeedback(for: result, profile: entry.name)
+                    handleKnockResult(result, entry: entry)
                 }
             }
 
             if isContinuous {
                 Button("Stop Continuous Knock") {
+                    continuousPostKnockFired.remove(entry.id)
                     knockManager.stopContinuousKnock()
                 }
                 .foregroundStyle(.orange)
             } else {
                 Button("Start Continuous Knock") {
+                    continuousPostKnockFired.remove(entry.id)
                     knockManager.startContinuousKnock(profile: entry.id) { result in
-                        showFeedback(for: result, profile: entry.name)
+                        handleKnockResult(result, entry: entry, isContinuous: true)
                     }
                 }
             }
@@ -158,6 +164,110 @@ struct MenuBarMenuView: View {
 
     // MARK: - Feedback
 
+    private func handleKnockResult(_ result: KnockResult, entry: ProfileEntry, isContinuous: Bool = false) {
+        switch result {
+        case .failure(let msg):
+            showFeedbackText("✗ \(entry.name): \(msg)")
+
+        case .success:
+            guard let profile = store.profile(named: entry.id) else {
+                showFeedbackText("✓ Knocked \(entry.name)")
+                return
+            }
+
+            let action = profile.postKnock.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // In continuous mode only run the post-knock action on the first
+            // successful knock; subsequent re-knocks just refresh the firewall rule.
+            let shouldRunAction = !action.isEmpty &&
+                (!isContinuous || !continuousPostKnockFired.contains(entry.id))
+
+            guard shouldRunAction else {
+                showFeedbackText("✓ Knocked \(entry.name)")
+                return
+            }
+
+            if isContinuous {
+                continuousPostKnockFired.insert(entry.id)
+            }
+
+            switch runPostKnockAction(action) {
+            case .success:
+                showFeedbackText("✓ Knocked \(entry.name) • post-knock launched")
+            case .failure(let err):
+                showFeedbackText("✓ Knocked \(entry.name) • post-knock failed: \(err.localizedDescription)")
+            }
+        }
+    }
+
+    private func showFeedbackText(_ text: String) {
+        feedbackTimer?.invalidate()
+        feedbackMessage = text
+        feedbackTimer = Timer.scheduledTimer(withTimeInterval: 4, repeats: false) { _ in
+            Task { @MainActor in
+                self.feedbackMessage = nil
+            }
+        }
+    }
+
+    /// Runs a post-knock action as either a URL or a shell command.
+    ///
+    /// URL mode:
+    /// - If `action` is a valid URL with a non-empty scheme (e.g. ssh://, http://),
+    ///   it is opened with the default macOS handler.
+    ///
+    /// Command mode:
+    /// - Otherwise, the action is executed in Terminal.app via AppleScript
+    ///   (e.g. `ssh user@host`).
+    private func runPostKnockAction(_ action: String) -> Result<Void, PostKnockError> {
+        // Treat explicit URL schemas as URL actions.
+        if let url = URL(string: action),
+           let scheme = url.scheme,
+           !scheme.isEmpty,
+           !action.contains(" ") {
+            if NSWorkspace.shared.urlForApplication(toOpen: url) == nil {
+                return .failure(PostKnockError("No app can open URL scheme '\(scheme)'."))
+            }
+            guard NSWorkspace.shared.open(url) else {
+                return .failure(PostKnockError("Could not open URL: \(action)"))
+            }
+            return .success(())
+        }
+
+        // Fallback: run as shell command in Terminal.app.
+        let escaped = action
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        let appleScript = "tell application \"Terminal\" to activate\n" +
+            "tell application \"Terminal\" to do script \"\(escaped)\""
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        proc.arguments = ["-e", appleScript]
+
+        let errPipe = Pipe()
+        proc.standardError = errPipe
+
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return .failure(PostKnockError("Failed to launch command: \(error.localizedDescription)"))
+        }
+
+        guard proc.terminationStatus == 0 else {
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let errText = String(data: errData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let errText, !errText.isEmpty {
+                return .failure(PostKnockError(errText))
+            }
+            return .failure(PostKnockError("Command launcher exited with code \(proc.terminationStatus)"))
+        }
+
+        return .success(())
+    }
+
     private func showFeedback(for result: KnockResult, profile: String) {
         feedbackTimer?.invalidate()
         switch result {
@@ -172,4 +282,14 @@ struct MenuBarMenuView: View {
             }
         }
     }
+}
+
+// MARK: - PostKnockError
+
+/// Lightweight `Error` wrapper for post-knock action failures.
+/// Used as the `Failure` type in `Result<Void, PostKnockError>` so that
+/// `Result` satisfies the `Error`-conforming constraint on its `Failure` type.
+private struct PostKnockError: LocalizedError {
+    let errorDescription: String?
+    init(_ message: String) { errorDescription = message }
 }

--- a/apple/openme-macos/openme-macos/Views/MenuBarMenuView.swift
+++ b/apple/openme-macos/openme-macos/Views/MenuBarMenuView.swift
@@ -195,7 +195,9 @@ struct MenuBarMenuView: View {
             case .success:
                 showFeedbackText("✓ Knocked \(entry.name) • post-knock launched")
             case .failure(let err):
-                showFeedbackText("✓ Knocked \(entry.name) • post-knock failed: \(err.localizedDescription)")
+                let msg = err.localizedDescription
+                print("[OpenMe] post-knock failed for '\(entry.name)': \(msg)")
+                showFeedbackText("✓ Knocked \(entry.name) • post-knock failed: \(msg)")
             }
         }
     }
@@ -210,61 +212,26 @@ struct MenuBarMenuView: View {
         }
     }
 
-    /// Runs a post-knock action as either a URL or a shell command.
+    /// Opens a URL after a successful knock using the default macOS handler.
     ///
-    /// URL mode:
-    /// - If `action` is a valid URL with a non-empty scheme (e.g. ssh://, http://),
-    ///   it is opened with the default macOS handler.
+    /// Supported schemes include anything registered with macOS — for example:
+    /// `ssh://`, `http://`, `https://`, `vnc://`, `rdp://`, `ftp://`.
     ///
-    /// Command mode:
-    /// - Otherwise, the action is executed in Terminal.app via AppleScript
-    ///   (e.g. `ssh user@host`).
+    /// Returns a failure if no application is registered for the scheme or if
+    /// `NSWorkspace` cannot open the URL.
     private func runPostKnockAction(_ action: String) -> Result<Void, PostKnockError> {
-        // Treat explicit URL schemas as URL actions.
-        if let url = URL(string: action),
-           let scheme = url.scheme,
-           !scheme.isEmpty,
-           !action.contains(" ") {
-            if NSWorkspace.shared.urlForApplication(toOpen: url) == nil {
-                return .failure(PostKnockError("No app can open URL scheme '\(scheme)'."))
-            }
-            guard NSWorkspace.shared.open(url) else {
-                return .failure(PostKnockError("Could not open URL: \(action)"))
-            }
-            return .success(())
+        guard let url = URL(string: action),
+              let scheme = url.scheme,
+              !scheme.isEmpty else {
+            return .failure(PostKnockError("'\(action)' is not a valid URL. Use a URL scheme such as ssh://, https://, or vnc://."))
         }
 
-        // Fallback: run as shell command in Terminal.app.
-        let escaped = action
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-
-        let appleScript = "tell application \"Terminal\" to activate\n" +
-            "tell application \"Terminal\" to do script \"\(escaped)\""
-
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        proc.arguments = ["-e", appleScript]
-
-        let errPipe = Pipe()
-        proc.standardError = errPipe
-
-        do {
-            try proc.run()
-            proc.waitUntilExit()
-        } catch {
-            return .failure(PostKnockError("Failed to launch command: \(error.localizedDescription)"))
+        if NSWorkspace.shared.urlForApplication(toOpen: url) == nil {
+            return .failure(PostKnockError("No app is registered for the '\(scheme)://' URL scheme."))
         }
-
-        guard proc.terminationStatus == 0 else {
-            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-            let errText = String(data: errData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let errText, !errText.isEmpty {
-                return .failure(PostKnockError(errText))
-            }
-            return .failure(PostKnockError("Command launcher exited with code \(proc.terminationStatus)"))
+        guard NSWorkspace.shared.open(url) else {
+            return .failure(PostKnockError("Could not open URL: \(action)"))
         }
-
         return .success(())
     }
 

--- a/apple/openme-macos/openme-macos/Views/ProfileManagerView.swift
+++ b/apple/openme-macos/openme-macos/Views/ProfileManagerView.swift
@@ -174,13 +174,17 @@ private struct ProfileDetailView: View {
                 .frame(maxWidth: .infinity)
 
                 // ── Post-knock ────────────────────────────────────────────────
-                GroupBox("Post-knock command (optional)") {
-                    FieldRow(label: "Shell command", hint: "open ssh://server.example.com") {
-                        TextField("ssh user@server.example.com", text: $profile.postKnock)
+                GroupBox("Post-knock URL (optional)") {
+                    FieldRow(label: "URL", hint: "ssh://user@server.example.com") {
+                        TextField("ssh://user@server.example.com", text: $profile.postKnock)
                             .font(.system(.caption, design: .monospaced))
                     }
                     .padding(.top, 4)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("Opened after a successful knock. Supports any registered URL scheme: ssh://, https://, vnc://, rdp://, etc.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 4)
                 }
                 .frame(maxWidth: .infinity)
             }


### PR DESCRIPTION
Fixes #37. 
Only URL shema support enabled (f.i. ssh://user@server.com or http://openme.merlos.org).